### PR TITLE
Encryption/Use preferences

### DIFF
--- a/encryption/README.md
+++ b/encryption/README.md
@@ -1,3 +1,26 @@
 #Demo encryption
 
-Encyption demonstrates how to use javax.crypto in Activities.
+Encryption demonstrates how to use javax.crypto in activities.
+
+Secret data is stored encrypted in default preferences using a hard coded key when leaving the activity.
+Therefore, there are two states:
+1. no encrypted data is stored and you have to re-enter the activity
+1. encrypted data is stored and you see both the encrypted and decrypted data.
+
+The demo can be used to see how the auto backup mechanism in Android M works with private data:
+
+Connect your M device, install the app
+```
+gw encryption:installDebug
+```
+and store the data. Then run the backup manager as decribed in the [preview documents](http://developer.android.com/preview/backup/index.html):
+```
+adb shell bmgr run
+adb shell bmgr fullbackup com.novoda.demo.encryption
+```
+Delete the preferences in the app and restore the data with
+```
+adb shell bmgr restore com.novoda.demo.encryption
+```
+Now you can continue with different transport services and different keys.
+

--- a/encryption/build.gradle
+++ b/encryption/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'com.android.application'
-
-
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 'android-MNC'
+    buildToolsVersion '23.0.0 rc2'
 
     defaultConfig {
         applicationId "com.novoda.demo.encryption"
-        minSdkVersion 3
-        targetSdkVersion 21
+        minSdkVersion 'MNC'
+        targetSdkVersion 'MNC'
         versionCode 1
         versionName "1.0"
     }
 }
 
+dependencies {
+}

--- a/encryption/src/main/AndroidManifest.xml
+++ b/encryption/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
+<manifest package="com.novoda.demo.encryption"
   xmlns:android="http://schemas.android.com/apk/res/android">
 
 

--- a/encryption/src/main/AndroidManifest.xml
+++ b/encryption/src/main/AndroidManifest.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="com.novoda"
-      android:versionCode="1"
-      android:versionName="1.0">
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
 
-    <application android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/Theme.Demo" >
-        <activity android:name=".Encrypt"
-                  android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+  <application
+    android:icon="@drawable/icon"
+    android:label="@string/app_name"
+    android:theme="@style/Theme.Demo">
+    <activity
+      android:name="com.novoda.demo.encryption.EncryptionActivity"
+      android:label="@string/app_name">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
 
-    </application>
+  </application>
 </manifest>

--- a/encryption/src/main/java/com/novoda/demo/encryption/Base64.java
+++ b/encryption/src/main/java/com/novoda/demo/encryption/Base64.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.novoda;
+package com.novoda.demo.encryption;
 
 
 // This code was converted from code at http://iharder.sourceforge.net/base64/

--- a/encryption/src/main/java/com/novoda/demo/encryption/Base64DecoderException.java
+++ b/encryption/src/main/java/com/novoda/demo/encryption/Base64DecoderException.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.novoda;
+package com.novoda.demo.encryption;
 
 /**
  * Exception thrown when encountering an invalid Base64 input character.

--- a/encryption/src/main/java/com/novoda/demo/encryption/EncryptionActivity.java
+++ b/encryption/src/main/java/com/novoda/demo/encryption/EncryptionActivity.java
@@ -1,4 +1,14 @@
-package com.novoda;
+package com.novoda.demo.encryption;
+
+import android.app.Activity;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.view.View;
+import android.widget.TextView;
+
+import com.novoda.R;
 
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidAlgorithmParameterException;
@@ -14,16 +24,12 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEParameterSpec;
 
-import android.app.Activity;
-import android.os.Bundle;
-import android.util.Log;
-import android.widget.TextView;
+public class EncryptionActivity extends Activity {
 
-public class Encrypt extends Activity {
-
-	private static final String SECRET_PASSWORD_TO_ENCRYPT = "secretPassword";
+	private static final String SECRET_DATA_TO_ENCRYPT = "secretPassword";
 	private static final String TAG = "Encrypt";
-	
+    private static final String PREFERENCE_KEY_SECURED_DATA = "KEY_SECURED_DATA";
+
     final String CIPHER_TYPE = "PBEWithMD5AndDES/CBC/PKCS5Padding";
     final String ALGORITHM = "PBEWithMD5AndDES";
     final String CHARSET = "UTF-8";
@@ -42,13 +48,17 @@ public class Encrypt extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
-        
-        String hash = getAsHash(SECRET_PASSWORD_TO_ENCRYPT);
-        
+
+        updateTextViews();
+    }
+
+    private void updateTextViews() {
+        String hash = PreferenceManager.getDefaultSharedPreferences(this).getString(PREFERENCE_KEY_SECURED_DATA, "Click the save button to store the password in preferences");
+
         ((TextView)findViewById(R.id.txt_encrypted)).setText(hash);
         ((TextView)findViewById(R.id.txt_unencrypted)).setText(getUnhashed(hash));
     }
-    
+
     public String getAsHash(String var) {
         String passwordHashed;
         try {
@@ -91,5 +101,17 @@ public class Encrypt extends Activity {
         }
         
         return result;
+    }
+
+    public void onSaveClick(View view){
+        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+        editor.putString(PREFERENCE_KEY_SECURED_DATA, getAsHash(SECRET_DATA_TO_ENCRYPT)).commit();
+        updateTextViews();
+    }
+
+    public void onDeleteClick(View view) {
+        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+        editor.clear().commit();
+        updateTextViews();
     }
 }

--- a/encryption/src/main/java/com/novoda/demo/encryption/EncryptionActivity.java
+++ b/encryption/src/main/java/com/novoda/demo/encryption/EncryptionActivity.java
@@ -8,8 +8,6 @@ import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 
-import com.novoda.R;
-
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;

--- a/encryption/src/main/res/layout/main.xml
+++ b/encryption/src/main/res/layout/main.xml
@@ -1,15 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/Fill">
-    
-    <LinearLayout style="@style/Fill.Width.Horizontal">
-		<TextView android:text="Encrypted: " />
-    	<TextView android:id="@+id/txt_encrypted" />
-    </LinearLayout>
+<LinearLayout
+  style="@style/Fill"
+  xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <LinearLayout style="@style/Fill.Width.Horizontal">
-    	<TextView android:text="After: " />
-    	<TextView android:id="@+id/txt_unencrypted" />
-    </LinearLayout>
+  <LinearLayout style="@style/Fill.Width.Horizontal">
+    <TextView
+      style="@style/Wrap"
+      android:text="Encrypted: " />
+    <TextView
+      android:id="@+id/txt_encrypted"
+      style="@style/Wrap" />
+  </LinearLayout>
 
+  <LinearLayout style="@style/Fill.Width.Horizontal">
+    <TextView
+      style="@style/Wrap"
+      android:text="After: " />
+    <TextView
+      android:id="@+id/txt_unencrypted"
+      style="@style/Wrap" />
+  </LinearLayout>
+
+  <Button
+    style="@style/Wrap"
+    android:onClick="onSaveClick"
+    android:text="Save encrypted password"/>
+
+  <Button
+    style="@style/Wrap"
+    android:onClick="onDeleteClick"
+    android:text="Delete encrypted password" />
 </LinearLayout>

--- a/encryption/src/main/res/values/strings.xml
+++ b/encryption/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="hello">Hello World, Encrypt!</string>
-    <string name="app_name">Encrypt</string>
+    <string name="app_name">Encryption</string>
 </resources>


### PR DESCRIPTION
This PR adds the two buttons below the text views for store encrypted data in preferences.

It also explains how to work with the auto backup feature introduced in Android M in the context of private data.

| After |
| --- |
| ![device-2015-07-09-151219](https://cloud.githubusercontent.com/assets/1449049/8596006/1243a69a-264d-11e5-89c8-2bbfe250c2f2.png) |