### PR TITLE
Turn on syntax highlighting by specifying `java`

### DIFF
--- a/Cookbook/change_device_locale_recipe.md
+++ b/Cookbook/change_device_locale_recipe.md
@@ -5,7 +5,7 @@ Internationalisation can be hard on Android so you might end up writing automate
 
 To avoid code duplication you can use this `TestRule`, which changes the `Locale` of a device to a given one before a test runs and afterwards back to the original one.
 
-```
+``` java
 class LocaleTestRule implements TestRule {
 
     private final Locale locale;
@@ -52,7 +52,7 @@ class LocaleTestRule implements TestRule {
 
 You can use this rule together with the `ActivityTestRule` in your instrumentation test.
 
-```
+``` java
 @RunWith(AndroidJUnit4.class)
 public class MainActivityTest {
 


### PR DESCRIPTION
[Not everyone agrees](http://www.linusakesson.net/programming/syntaxhighlighting/), but I like syntax highlighting.

Before | After 
----- | -----
![img_6029](https://cloud.githubusercontent.com/assets/3073183/22078976/0a61b4bc-ddb2-11e6-8cfd-01a6ed330f95.PNG) | ![img_6030](https://cloud.githubusercontent.com/assets/3073183/22078977/0a9865d4-ddb2-11e6-8d7e-3e6aa6ce1090.PNG)
