### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CarouselFragment/README.md
+++ b/CarouselFragment/README.md
@@ -1,4 +1,4 @@
-#Demo CarouselFragment
+# Demo CarouselFragment
 
 The CarouselFragment demonstrates how to select content using the (deprecated) Gallery widget on TV.
 

--- a/CompassExample/README.md
+++ b/CompassExample/README.md
@@ -1,4 +1,4 @@
-#Demo CompassExample
+# Demo CompassExample
 
 Demonstrates use of the deprecated Novocation library. The app works only for pre-jellybean devices.
 

--- a/ContactSelector/README.md
+++ b/ContactSelector/README.md
@@ -1,4 +1,4 @@
-#Demo ContactSelector
+# Demo ContactSelector
 
 ContactSelector demonstrates the use of the pick action for contacts.
 

--- a/Cookbook/add_native_express_adverts.md
+++ b/Cookbook/add_native_express_adverts.md
@@ -52,13 +52,13 @@ There is a table in the documentation summarising available sizes
 
 The process is the same as loading a regular ad:
 
-####1. In the activity, initialise `MobileAds`:
+#### 1. In the activity, initialise `MobileAds`:
 
 ```
 MobileAds.initialize(getApplicationContext(), getString(R.string.ad_app_id));
 ```
 
-####2. Load the view and build a request:
+#### 2. Load the view and build a request:
 
 ```
 NativeExpressAdView mAdView = (NativeExpressAdView) findViewById(R.id.adViewExpress);

--- a/CustomActivityTransition/README.md
+++ b/CustomActivityTransition/README.md
@@ -1,4 +1,4 @@
-#Demo CustomActivityTransition
+# Demo CustomActivityTransition
 
 CustomActivityTransition demonstrates how to define animations in the application theme.
 

--- a/DynamicListItems/README.md
+++ b/DynamicListItems/README.md
@@ -1,3 +1,3 @@
-#Demo DynamicListItems
+# Demo DynamicListItems
 
 DynamicListItems shows how to add items to a listview at runtime.

--- a/EditTextChips/README.md
+++ b/EditTextChips/README.md
@@ -1,4 +1,4 @@
-#Demo EditTextChips
+# Demo EditTextChips
 
 EditTextChips shows different libraries to display 'chips' in an EditText (usually used to show tags, email addresses, etc.).
 

--- a/FixedSizeTextColumns/README.md
+++ b/FixedSizeTextColumns/README.md
@@ -1,4 +1,4 @@
-#Demo FixedSizeTextColumns
+# Demo FixedSizeTextColumns
 
 FixedSizeTextColumns shows how WebView behaves with different font sizes.
 

--- a/Fragments/README.md
+++ b/Fragments/README.md
@@ -1,4 +1,4 @@
-#Demo Fragments
+# Demo Fragments
 
 Fragments demonstrates how to use activities and fragments for basic master/detail layout.
 

--- a/GsonJsonWebservice/README.md
+++ b/GsonJsonWebservice/README.md
@@ -1,4 +1,4 @@
-#Demo GsonJsonWebservice
+# Demo GsonJsonWebservice
 
 GsonJsonWebservice demonstrates how to make a request to twitter.
 

--- a/LeftNavBarExample/Example/README.md
+++ b/LeftNavBarExample/Example/README.md
@@ -1,4 +1,4 @@
-#Demo LeftNavBarExample/Example
+# Demo LeftNavBarExample/Example
 
 Example show how to use the left navigation bar for TV.
 

--- a/LeftNavBarExample/LeftNavBarLibrary/README.md
+++ b/LeftNavBarExample/LeftNavBarLibrary/README.md
@@ -1,2 +1,2 @@
-#Demo LeftNavBarExample/LeftNavBarLibrary
+# Demo LeftNavBarExample/LeftNavBarLibrary
 

--- a/ListStyles/README.md
+++ b/ListStyles/README.md
@@ -1,3 +1,3 @@
-#Demo ListStyles
+# Demo ListStyles
 
 ListStyles demonstrates how to programmatically defined list item layouts.

--- a/Livewallpaper/switch_animation/README.md
+++ b/Livewallpaper/switch_animation/README.md
@@ -1,4 +1,4 @@
-#Demo Livewallpaper/switch_animation
+# Demo Livewallpaper/switch_animation
 
 switch_animation demonstrates how to live wall papers with animations
 

--- a/Livewallpaper/switch_leftright/README.md
+++ b/Livewallpaper/switch_leftright/README.md
@@ -1,4 +1,4 @@
-#Demo Livewallpaper/switch_leftright
+# Demo Livewallpaper/switch_leftright
 
 switch_leftright demonstrates how to live wall papers with animations
 

--- a/MultipleContacts/README.md
+++ b/MultipleContacts/README.md
@@ -1,4 +1,4 @@
-#Demo MultipleContacts
+# Demo MultipleContacts
 
 MultipleContacts demonstrates multi-auto-completion with contacts.
 

--- a/OptionalDependencies/README.md
+++ b/OptionalDependencies/README.md
@@ -1,4 +1,4 @@
-#Demo OptionalDependencies [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt)
+# Demo OptionalDependencies [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt)
 
 OptionalDependencies shows how to create two product flavours that have different implementations of one method.
 

--- a/PinchZoomDetector/README.md
+++ b/PinchZoomDetector/README.md
@@ -1,3 +1,3 @@
-#Demo PinchZoomDetector
+# Demo PinchZoomDetector
 
 PinchZoomDetector demonstrates how to add pinch to zoom gesture to an activity.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Android Demos [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt)
+# Android Demos [![](https://raw.githubusercontent.com/novoda/novoda/master/assets/btn_apache_lisence.png)](LICENSE.txt)
 
 This is a collection of basic android examples created by Novoda.
 
@@ -26,7 +26,7 @@ This is a collection of basic android examples created by Novoda.
 * [TabHostSelfContainedTabBrowsing](http://github.com/novoda/android-demos/tree/master/TabHostSelfContainedTabBrowsing)
 * [wizard](http://github.com/novoda/android-demos/tree/master/wizard)
 
-#Demos of Novoda Open Source (NOS) libraries and projects
+# Demos of Novoda Open Source (NOS) libraries and projects
 
 * [Simple Demo for Download Manager](https://github.com/novoda/download-manager/tree/master/demo-simple)
 * [Extended Demo for Download Manager](https://github.com/novoda/download-manager/tree/master/demo-extended)
@@ -37,9 +37,9 @@ This is a collection of basic android examples created by Novoda.
 * [Demo for Merlin (network connectivity)](https://github.com/novoda/merlin/tree/master/demo)
 * [Demo for simple XML parsing](https://github.com/novoda/simple-easy-xml-parser/tree/master/demoAndroid)
 
-#Further NOS work
+# Further NOS work
 
-##All NOS libraries
+## All NOS libraries
 
 * [Download Manager](https://github.com/novoda/download-manager)
 * [Merlin - Connectivity Checker](https://github.com/novoda/merlin)
@@ -49,7 +49,7 @@ This is a collection of basic android examples created by Novoda.
 * [Simple XML Parser](https://github.com/novoda/simple-easy-xml-parser)
 * [RxPresso](https://github.com/novoda/rxpresso)
 
-##All NOS gradle plugins
+## All NOS gradle plugins
 
 * [Bintray Release](https://github.com/novoda/bintray-release)
 * [Sqlite Analyzer](https://github.com/novoda/sqlite-analyzer)

--- a/Sandbox/README.MD
+++ b/Sandbox/README.MD
@@ -14,7 +14,7 @@ Anyone of:
  - Sikuli
  
 
-####Current Acceptance Criteria:
+#### Current Acceptance Criteria:
  
  Main screen:
  

--- a/TabHostExample/README.md
+++ b/TabHostExample/README.md
@@ -1,3 +1,3 @@
-#Demo TabHostExample
+# Demo TabHostExample
 
 TabHostExample shows how to use the TabHost class.

--- a/TabHostSelfContainedTabBrowsing/README.md
+++ b/TabHostSelfContainedTabBrowsing/README.md
@@ -1,3 +1,3 @@
-#Demo TabHostSelfContainedTabBrowsing
+# Demo TabHostSelfContainedTabBrowsing
 
 TabHostSelfContainedTabBrowsing demonstrates a simple use of `TabHost` class with navigation between tabs.

--- a/WearBuildConfig/README.md
+++ b/WearBuildConfig/README.md
@@ -1,4 +1,4 @@
-#Demo WearBuildConfig
+# Demo WearBuildConfig
 
 WearBuildConfig demonstrates how to integrate Android Wear with a real-world mobile project with the following requirements:
 

--- a/encryption/README.md
+++ b/encryption/README.md
@@ -1,3 +1,3 @@
-#Demo encryption
+# Demo encryption
 
 Encyption demonstrates how to use javax.crypto in Activities.

--- a/simperAudioStreamer/README.md
+++ b/simperAudioStreamer/README.md
@@ -1,4 +1,4 @@
-#Demo simperAudioStreamer
+# Demo simperAudioStreamer
 
 simperAudioStreamer demonstrates how to provide a simple audio stream service.
 

--- a/sms/README.md
+++ b/sms/README.md
@@ -1,4 +1,4 @@
-#Demo sms
+# Demo sms
 
 sms demonstrates how to send SMS using the `SmsManager`.
 

--- a/wizard/README.md
+++ b/wizard/README.md
@@ -1,4 +1,4 @@
-#Demo wizard
+# Demo wizard
 
 wizard shows how to click through several activities in a wizzard like manner.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
