### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -9,6 +10,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
Change google() repository & jcenter() repository access priority so that the gradle build would not fail to resolve dependencies as per latest Android Studio update.

Reference: https://stackoverflow.com/questions/50584437/android-studio-3-1-2-failed-to-resolve-runtime/50758769