### PR TITLE
[MVI] Reduce state with state changes

### DIFF
--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
@@ -11,7 +11,7 @@ class BaseStore<A, S, C>(
     private val middlewares: List<Middleware<A, S, C>>,
     private val initialValue: S
 ) : Store<A, S, C> {
-    private val changes = BehaviorSubject.create<C>()
+    private val changes = PublishSubject.create<C>()
     private val state = BehaviorSubject.createDefault(initialValue)
     private val actions: PublishSubject<A> = PublishSubject.create()
 

--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
@@ -2,7 +2,6 @@ package com.novoda.movies.mvi.search
 
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
-import io.reactivex.functions.BiFunction
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
@@ -10,7 +9,7 @@ class BaseStore<A, S, C>(
     private val schedulingStrategy: SchedulingStrategy,
     private val reducer: Reducer<S, C>,
     private val middlewares: List<Middleware<A, S, C>>,
-    initialValue: S
+    private val initialValue: S
 ) : Store<A, S, C> {
     private val changes = BehaviorSubject.create<C>()
     private val state = BehaviorSubject.createDefault(initialValue)
@@ -18,18 +17,23 @@ class BaseStore<A, S, C>(
 
     override fun wire(): Disposable {
         val disposables = CompositeDisposable()
-        val newState = changes.withLatestFrom(state, BiFunction<C, S, S> { change, state ->
-            reducer.reduce(state, change)
-        })
-        disposables.add(newState
+
+        val newState = changes.scan(
+            initialValue, { state, change ->
+                reducer.reduce(state, change)
+            }
+        )
+
+        disposables.add(
+            newState
                 .subscribeOn(schedulingStrategy.work)
                 .subscribe(state::onNext)
         )
 
         for (middleware in middlewares) {
             val observable = middleware
-                    .bind(actions, state)
-                    .subscribeOn(schedulingStrategy.work)
+                .bind(actions, state)
+                .subscribeOn(schedulingStrategy.work)
             disposables.add(observable.subscribe(changes::onNext))
         }
 
@@ -41,7 +45,8 @@ class BaseStore<A, S, C>(
 
         disposables.add(view.actions.subscribe(actions::onNext))
 
-        disposables.add(state
+        disposables.add(
+            state
                 .observeOn(schedulingStrategy.ui)
                 .subscribe(view::render)
         )

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -28,7 +28,7 @@ internal class SearchDependencyProvider(
             reducer = SearchReducer(provideSearchResultsConverter()),
             schedulingStrategy = ProductionSchedulingStrategy(),
             middlewares = listOf(SearchMiddleware(provideSearchBackend(), ProductionSchedulingStrategy().work)),
-            initialValue = ScreenState(queryString = "", results = ViewSearchResults())
+            initialValue = ScreenState(queryString = "", results = ViewSearchResults.emptyResults)
         )
     }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -28,7 +28,7 @@ internal class SearchDependencyProvider(
             reducer = SearchReducer(provideSearchResultsConverter()),
             schedulingStrategy = ProductionSchedulingStrategy(),
             middlewares = listOf(SearchMiddleware(provideSearchBackend(), ProductionSchedulingStrategy().work)),
-            initialValue = ScreenState.Content(queryString = "", results = ViewSearchResults())
+            initialValue = ScreenState(queryString = "", results = ViewSearchResults())
         )
     }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -23,12 +23,12 @@ internal class SearchDependencyProvider(
         )
     }
 
-    fun provideSearchStore(): BaseStore<SearchAction, SearchState, SearchChanges> {
+    fun provideSearchStore(): BaseStore<SearchAction, ScreenState, ScreenStateChanges> {
         return BaseStore(
             reducer = SearchReducer(provideSearchResultsConverter()),
             schedulingStrategy = ProductionSchedulingStrategy(),
             middlewares = listOf(SearchMiddleware(provideSearchBackend(), ProductionSchedulingStrategy().work)),
-            initialValue = SearchState.Content(queryString = "", results = ViewSearchResults())
+            initialValue = ScreenState.Content(queryString = "", results = ViewSearchResults())
         )
     }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -33,7 +33,7 @@ internal class SearchMiddleware(
         return backend.search(state.queryString)
                 .toObservable()
                 .map { searchResult -> AddResults(searchResult) as ScreenStateChanges }
-                .startWith(IndicateProgress)
+                .startWith(ShowProgress)
                 .onErrorReturn { throwable -> HandleError(throwable) }
                 .subscribeOn(workScheduler)
     }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -2,12 +2,7 @@ package com.novoda.movies.mvi.search.domain
 
 import com.novoda.movies.mvi.search.Middleware
 import com.novoda.movies.mvi.search.data.SearchBackend
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges.AddResults
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges.HandleError
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges.HideProgress
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges.RemoveResults
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges.ShowProgress
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges.UpdateSearchQuery
+import com.novoda.movies.mvi.search.domain.ScreenStateChanges.*
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.functions.BiFunction
@@ -35,9 +30,9 @@ internal class SearchMiddleware(
             }
 
     private fun processClearQuery(): Observable<ScreenStateChanges> {
-        val updateSearch = Observable.just(UpdateSearchQuery("") as ScreenStateChanges)
+        val updateQuery = Observable.just(UpdateSearchQuery("") as ScreenStateChanges)
         val removeResults = Observable.just(RemoveResults)
-        return updateSearch.concatWith(removeResults)
+        return updateQuery.concatWith(removeResults)
     }
 
     private fun processAction(state: ScreenState): Observable<ScreenStateChanges> {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -2,7 +2,7 @@ package com.novoda.movies.mvi.search.domain
 
 import com.novoda.movies.mvi.search.Middleware
 import com.novoda.movies.mvi.search.data.SearchBackend
-import com.novoda.movies.mvi.search.domain.SearchChanges.*
+import com.novoda.movies.mvi.search.domain.ScreenStateChanges.*
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 import io.reactivex.Observable
 import io.reactivex.Scheduler
@@ -12,30 +12,30 @@ import io.reactivex.functions.BiFunction
 internal class SearchMiddleware(
         private val backend: SearchBackend,
         private val workScheduler: Scheduler
-) : Middleware<SearchAction, SearchState, SearchChanges> {
+) : Middleware<SearchAction, ScreenState, ScreenStateChanges> {
 
-    override fun bind(actions: Observable<SearchAction>, state: Observable<SearchState>): Observable<SearchChanges> {
+    override fun bind(actions: Observable<SearchAction>, state: Observable<ScreenState>): Observable<ScreenStateChanges> {
         return actions
                 .withLatestFrom(state, actionToState())
                 .switchMap { (action, state) -> handle(action, state) }
     }
 
-    private fun actionToState(): BiFunction<SearchAction, SearchState, Pair<SearchAction, SearchState>> =
+    private fun actionToState(): BiFunction<SearchAction, ScreenState, Pair<SearchAction, ScreenState>> =
             BiFunction { action, state -> action to state }
 
-    private fun handle(action: SearchAction, state: SearchState): Observable<SearchChanges> =
+    private fun handle(action: SearchAction, state: ScreenState): Observable<ScreenStateChanges> =
             when (action) {
-                is SearchAction.ChangeQuery -> Observable.just(SearchQueryUpdate(action.queryString))
+                is SearchAction.ChangeQuery -> Observable.just(ScreenStateQueryUpdate(action.queryString))
                 is SearchAction.ExecuteSearch -> processAction(state)
-                is SearchAction.ClearQuery -> Observable.just(SearchQueryUpdate(""))
+                is SearchAction.ClearQuery -> Observable.just(ScreenStateQueryUpdate(""))
             }
 
-    private fun processAction(state: SearchState): Observable<SearchChanges> {
+    private fun processAction(state: ScreenState): Observable<ScreenStateChanges> {
         return backend.search(state.queryString)
                 .toObservable()
-                .map { searchResult -> SearchCompleted(searchResult) as SearchChanges }
-                .startWith(SearchInProgress)
-                .onErrorReturn { throwable -> SearchFailed(throwable) }
+                .map { searchResult -> ScreenStateCompleted(searchResult) as ScreenStateChanges }
+                .startWith(ScreenStateInProgress)
+                .onErrorReturn { throwable -> ScreenStateFailed(throwable) }
                 .subscribeOn(workScheduler)
     }
 }
@@ -47,19 +47,19 @@ internal sealed class SearchAction {
 }
 
 
-internal sealed class SearchState {
+internal sealed class ScreenState {
 
     abstract val queryString: String
 
-    data class Content(override val queryString: String, val results: ViewSearchResults) : SearchState()
-    data class Loading(override val queryString: String) : SearchState()
-    data class Error(override val queryString: String, val throwable: Throwable) : SearchState()
+    data class Content(override val queryString: String, val results: ViewSearchResults) : ScreenState()
+    data class Loading(override val queryString: String) : ScreenState()
+    data class Error(override val queryString: String, val throwable: Throwable) : ScreenState()
 }
 
-sealed class SearchChanges {
+sealed class ScreenStateChanges {
 
-    object SearchInProgress : SearchChanges()
-    data class SearchCompleted(val results: SearchResults) : SearchChanges()
-    data class SearchFailed(val throwable: Throwable) : SearchChanges()
-    data class SearchQueryUpdate(val queryString: String) : SearchChanges()
+    object ScreenStateInProgress : ScreenStateChanges()
+    data class ScreenStateCompleted(val results: SearchResults) : ScreenStateChanges()
+    data class ScreenStateFailed(val throwable: Throwable) : ScreenStateChanges()
+    data class ScreenStateQueryUpdate(val queryString: String) : ScreenStateChanges()
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
@@ -10,20 +10,37 @@ internal class SearchReducer(
 
     override fun reduce(state: ScreenState, change: ScreenStateChanges): ScreenState =
         when (change) {
-            ScreenStateChanges.ScreenStateInProgress -> ScreenState.Loading(
+            ScreenStateChanges.IndicateProgress -> ScreenState.Loading(
                 queryString = state.queryString
             )
-            is ScreenStateChanges.ScreenStateCompleted -> ScreenState.Content(
+            is ScreenStateChanges.AddResults -> ScreenState.Content(
                 queryString = state.queryString,
                 results = searchResultsConverter.convert(change.results)
             )
-            is ScreenStateChanges.ScreenStateFailed -> ScreenState.Error(
+            is ScreenStateChanges.HandleError -> ScreenState.Error(
                 queryString = state.queryString,
                 throwable = change.throwable
             )
-            is ScreenStateChanges.ScreenStateQueryUpdate -> ScreenState.Content(
+            is ScreenStateChanges.UpdateSearchQuery -> ScreenState.Content(
                 queryString = change.queryString,
                 results = ViewSearchResults()
             )
         }
+}
+
+internal sealed class ScreenState {
+
+    abstract val queryString: String
+
+    data class Content(override val queryString: String, val results: ViewSearchResults) : ScreenState()
+    data class Loading(override val queryString: String) : ScreenState()
+    data class Error(override val queryString: String, val throwable: Throwable) : ScreenState()
+}
+
+sealed class ScreenStateChanges {
+
+    object IndicateProgress : ScreenStateChanges()
+    data class AddResults(val results: SearchResults) : ScreenStateChanges()
+    data class HandleError(val throwable: Throwable) : ScreenStateChanges()
+    data class UpdateSearchQuery(val queryString: String) : ScreenStateChanges()
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
@@ -43,7 +43,6 @@ private fun ScreenState.showLoading(): ScreenState {
     return copy(loading = true)
 }
 
-
 internal data class ScreenState(
     var queryString: String,
     var loading: Boolean = false,

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
@@ -6,22 +6,22 @@ import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 
 internal class SearchReducer(
     private val searchResultsConverter: SearchResultsConverter
-) : Reducer<SearchState, SearchChanges> {
+) : Reducer<ScreenState, ScreenStateChanges> {
 
-    override fun reduce(state: SearchState, change: SearchChanges): SearchState =
+    override fun reduce(state: ScreenState, change: ScreenStateChanges): ScreenState =
         when (change) {
-            SearchChanges.SearchInProgress -> SearchState.Loading(
+            ScreenStateChanges.ScreenStateInProgress -> ScreenState.Loading(
                 queryString = state.queryString
             )
-            is SearchChanges.SearchCompleted -> SearchState.Content(
+            is ScreenStateChanges.ScreenStateCompleted -> ScreenState.Content(
                 queryString = state.queryString,
                 results = searchResultsConverter.convert(change.results)
             )
-            is SearchChanges.SearchFailed -> SearchState.Error(
+            is ScreenStateChanges.ScreenStateFailed -> ScreenState.Error(
                 queryString = state.queryString,
                 throwable = change.throwable
             )
-            is SearchChanges.SearchQueryUpdate -> SearchState.Content(
+            is ScreenStateChanges.ScreenStateQueryUpdate -> ScreenState.Content(
                 queryString = change.queryString,
                 results = ViewSearchResults()
             )

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
@@ -10,9 +10,10 @@ internal class SearchReducer(
 
     override fun reduce(state: ScreenState, change: ScreenStateChanges): ScreenState =
         when (change) {
-            ScreenStateChanges.ShowProgress -> state.showLoading()
-            ScreenStateChanges.HideProgress -> state.hideLoading()
+            is ScreenStateChanges.ShowProgress -> state.showLoading()
+            is ScreenStateChanges.HideProgress -> state.hideLoading()
             is ScreenStateChanges.AddResults -> state.addResults(change.results)
+            is ScreenStateChanges.RemoveResults -> state.removeResults()
             is ScreenStateChanges.UpdateSearchQuery -> state.updateQuery(change.queryString)
             is ScreenStateChanges.HandleError -> state.toError(change.throwable)
         }
@@ -20,7 +21,10 @@ internal class SearchReducer(
     private fun ScreenState.addResults(results: SearchResults): ScreenState {
         return copy(results = searchResultsConverter.convert(results))
     }
+}
 
+private fun ScreenState.removeResults(): ScreenState {
+    return copy(results = ViewSearchResults.emptyResults)
 }
 
 private fun ScreenState.toError(throwable: Throwable): ScreenState {
@@ -43,7 +47,7 @@ private fun ScreenState.showLoading(): ScreenState {
 internal data class ScreenState(
     var queryString: String,
     var loading: Boolean = false,
-    var results: ViewSearchResults? = null,
+    var results: ViewSearchResults,
     var error: Throwable? = null
 )
 
@@ -52,6 +56,7 @@ sealed class ScreenStateChanges {
     object ShowProgress : ScreenStateChanges()
     object HideProgress : ScreenStateChanges()
     data class AddResults(val results: SearchResults) : ScreenStateChanges()
+    object RemoveResults: ScreenStateChanges()
     data class HandleError(val throwable: Throwable) : ScreenStateChanges()
     data class UpdateSearchQuery(val queryString: String) : ScreenStateChanges()
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -44,12 +44,10 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Scree
     }
 
     override fun render(state: ScreenState) {
-
         if (state.results != null) {
             searchInput.currentQuery = state.queryString
             resultsView.showResults(state.results!!)
         }
-
 
         Log.v("APP", "state: $state")
     }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -8,19 +8,19 @@ import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.MVIView
 import com.novoda.movies.mvi.search.R
 import com.novoda.movies.mvi.search.domain.SearchAction
-import com.novoda.movies.mvi.search.domain.SearchChanges
+import com.novoda.movies.mvi.search.domain.ScreenStateChanges
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
-import com.novoda.movies.mvi.search.domain.SearchState
+import com.novoda.movies.mvi.search.domain.ScreenState
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.activity_search.*
 
-internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, SearchState> {
+internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, ScreenState> {
 
     private lateinit var searchInput: SearchInputView
     private lateinit var resultsView: SearchResultsView
 
-    lateinit var searchStore: BaseStore<SearchAction, SearchState, SearchChanges>
+    lateinit var screenStore: BaseStore<SearchAction, ScreenState, ScreenStateChanges>
 
     override val actions: Observable<SearchAction>
         get() = searchInput.actions
@@ -35,17 +35,17 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Searc
         searchInput = search_input
         resultsView = search_results
 
-        wireDisposable = searchStore.wire()
+        wireDisposable = screenStore.wire()
     }
 
     override fun onStart() {
         super.onStart()
-        bindDisposable = searchStore.bind(this)
+        bindDisposable = screenStore.bind(this)
     }
 
-    override fun render(state: SearchState) {
+    override fun render(state: ScreenState) {
         when (state) {
-            is SearchState.Content -> {
+            is ScreenState.Content -> {
                 searchInput.currentQuery = state.queryString
                 resultsView.showResults(state.results)
             }
@@ -74,7 +74,7 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Searc
                     networkDependencyProvider,
                     dependencies.endpoints
             )
-            searchActivity.searchStore = searchDependencyProvider.provideSearchStore()
+            searchActivity.screenStore = searchDependencyProvider.provideSearchStore()
         }
     }
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -7,10 +7,10 @@ import com.novoda.movies.mvi.search.BaseStore
 import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.MVIView
 import com.novoda.movies.mvi.search.R
-import com.novoda.movies.mvi.search.domain.SearchAction
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges
-import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
 import com.novoda.movies.mvi.search.domain.ScreenState
+import com.novoda.movies.mvi.search.domain.ScreenStateChanges
+import com.novoda.movies.mvi.search.domain.SearchAction
+import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.activity_search.*
@@ -44,15 +44,13 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Scree
     }
 
     override fun render(state: ScreenState) {
-        when (state) {
-            is ScreenState.Content -> {
-                searchInput.currentQuery = state.queryString
-                resultsView.showResults(state.results)
-            }
 
-            //TODO: Handle Loading
-            //TODO: Handle Error
+        if (state.results != null) {
+            searchInput.currentQuery = state.queryString
+            resultsView.showResults(state.results!!)
         }
+
+
         Log.v("APP", "state: $state")
     }
 
@@ -71,8 +69,8 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Scree
             val dependencies = searchActivity.application as Dependencies
             val networkDependencyProvider = dependencies.networkDependencyProvider
             val searchDependencyProvider = SearchDependencyProvider(
-                    networkDependencyProvider,
-                    dependencies.endpoints
+                networkDependencyProvider,
+                dependencies.endpoints
             )
             searchActivity.screenStore = searchDependencyProvider.provideSearchStore()
         }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -44,10 +44,8 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Scree
     }
 
     override fun render(state: ScreenState) {
-        if (state.results != null) {
-            searchInput.currentQuery = state.queryString
-            resultsView.showResults(state.results!!)
-        }
+        searchInput.currentQuery = state.queryString
+        resultsView.showResults(state.results)
 
         Log.v("APP", "state: $state")
     }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/ViewSearchResults.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/ViewSearchResults.kt
@@ -3,9 +3,13 @@ package com.novoda.movies.mvi.search.presentation
 import java.net.URL
 
 internal data class ViewSearchResults(
-    val totalItemCount: Int = 0,
-    val items: List<ViewSearchItem> = emptyList()
-)
+    val totalItemCount: Int,
+    val items: List<ViewSearchItem>
+) {
+    companion object {
+        val emptyResults = ViewSearchResults(0, emptyList())
+    }
+}
 
 internal data class ViewSearchItem(
     val id: String,

--- a/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
+++ b/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
@@ -32,7 +32,7 @@ class SearchMiddlewareTest {
 
         actions.onNext(SearchAction.ChangeQuery(queryString = "superman"))
 
-        changes.assertValue(ScreenStateChanges.ScreenStateQueryUpdate("superman"))
+        changes.assertValue(ScreenStateChanges.UpdateSearchQuery("superman"))
     }
 
     @Test
@@ -41,7 +41,7 @@ class SearchMiddlewareTest {
 
         actions.onNext(SearchAction.ClearQuery)
 
-        changes.assertValue(ScreenStateChanges.ScreenStateQueryUpdate(""))
+        changes.assertValue(ScreenStateChanges.UpdateSearchQuery(""))
     }
 
     @Test
@@ -53,8 +53,8 @@ class SearchMiddlewareTest {
         actions.onNext(SearchAction.ExecuteSearch)
 
         changes.assertValues(
-            ScreenStateChanges.ScreenStateInProgress,
-            ScreenStateChanges.ScreenStateCompleted(results = searchResults)
+            ScreenStateChanges.IndicateProgress,
+            ScreenStateChanges.AddResults(results = searchResults)
         )
     }
 
@@ -67,8 +67,8 @@ class SearchMiddlewareTest {
         actions.onNext(SearchAction.ExecuteSearch)
 
         changes.assertValues(
-            ScreenStateChanges.ScreenStateInProgress,
-            ScreenStateChanges.ScreenStateFailed(exception)
+            ScreenStateChanges.IndicateProgress,
+            ScreenStateChanges.HandleError(exception)
         )
     }
 }


### PR DESCRIPTION
## Description
This addresses an issue that @mr-archano pointed out, where the `SearchReducer` was highly coupled to the `SearchMiddleWare`, which produced domain-specific change events.

We changed that so that the `SearchMiddleWare` now emits `ScreenStateChanges` which are then applied to the state. These `ScreenStateChanges` do not leak any internals of our business logic. This also means that our changes need to be more fine granular, meaning we need more events. E.g. `ShowLoading`, `HideLoading` or `AddResults`, `RemoveResults`.

Furthermore, we changed the reducer pipeline to use the `scan` operator rather then combining the last state with the changes using `withLatestFrom`.

## Paired with
@zegnus 