### PR TITLE
MVI ViewModel 

### DIFF
--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
@@ -40,7 +40,7 @@ class BaseStore<A, S, C>(
         return disposables
     }
 
-    override fun bind(actionProvider: ActionProvider<A>, viewRender: ViewRender<S>): Disposable {
+    override fun bind(actionProvider: ActionProvider<A>, displayer: Displayer<S>): Disposable {
         val disposables = CompositeDisposable()
 
         disposables.add(actionProvider.actions.subscribe(actions::onNext))
@@ -48,7 +48,7 @@ class BaseStore<A, S, C>(
         disposables.add(
             state
                 .observeOn(schedulingStrategy.ui)
-                .subscribe(viewRender::render)
+                .subscribe(displayer::render)
         )
 
         return disposables

--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
@@ -6,10 +6,10 @@ import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
 class BaseStore<A, S, C>(
-    private val schedulingStrategy: SchedulingStrategy,
-    private val reducer: Reducer<S, C>,
-    private val middlewares: List<Middleware<A, S, C>>,
-    private val initialValue: S
+        private val schedulingStrategy: SchedulingStrategy,
+        private val reducer: Reducer<S, C>,
+        private val middlewares: List<Middleware<A, S, C>>,
+        private val initialValue: S
 ) : Store<A, S, C> {
     private val changes = PublishSubject.create<C>()
     private val state = BehaviorSubject.createDefault(initialValue)
@@ -19,36 +19,36 @@ class BaseStore<A, S, C>(
         val disposables = CompositeDisposable()
 
         val newState = changes.scan(
-            initialValue, { state, change ->
-                reducer.reduce(state, change)
-            }
+                initialValue, { state, change ->
+            reducer.reduce(state, change)
+        }
         )
 
         disposables.add(
-            newState
-                .subscribeOn(schedulingStrategy.work)
-                .subscribe(state::onNext)
+                newState
+                        .subscribeOn(schedulingStrategy.work)
+                        .subscribe(state::onNext)
         )
 
         for (middleware in middlewares) {
             val observable = middleware
-                .bind(actions, state)
-                .subscribeOn(schedulingStrategy.work)
+                    .bind(actions, state)
+                    .subscribeOn(schedulingStrategy.work)
             disposables.add(observable.subscribe(changes::onNext))
         }
 
         return disposables
     }
 
-    override fun bind(actionProvider: ActionProvider<A>, displayer: Displayer<S>): Disposable {
+    override fun bind(displayer: Displayer<A, S>): Disposable {
         val disposables = CompositeDisposable()
 
-        disposables.add(actionProvider.actions.subscribe(actions::onNext))
+        disposables.add(displayer.actions.subscribe(actions::onNext))
 
         disposables.add(
-            state
-                .observeOn(schedulingStrategy.ui)
-                .subscribe(displayer::render)
+                state
+                        .observeOn(schedulingStrategy.ui)
+                        .subscribe(displayer::render)
         )
 
         return disposables

--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/BaseStore.kt
@@ -36,14 +36,14 @@ class BaseStore<A, S, C>(
         return disposables
     }
 
-    override fun bind(view: MVIView<A, S>): Disposable {
+    override fun bind(actionProvider: ActionProvider<A>, viewRender: ViewRender<S>): Disposable {
         val disposables = CompositeDisposable()
 
-        disposables.add(view.actions.subscribe(actions::onNext))
+        disposables.add(actionProvider.actions.subscribe(actions::onNext))
 
         disposables.add(state
                 .observeOn(schedulingStrategy.ui)
-                .subscribe(view::render)
+                .subscribe(viewRender::render)
         )
 
         return disposables

--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/MVI.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/MVI.kt
@@ -3,11 +3,11 @@ package com.novoda.movies.mvi.search
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 
-// TODO: Consider a better interface for the view so that we can compose
-// more views in the same Activity
-interface MVIView<A, S> {
+interface ActionProvider<A> {
     val actions: Observable<A>
+}
 
+interface ViewRender<S> {
     fun render(state: S)
 }
 
@@ -21,5 +21,5 @@ interface Middleware<A, S, C> {
 
 interface Store<A, S, C> {
     fun wire(): Disposable
-    fun bind(view: MVIView<A, S>): Disposable
+    fun bind(actionProvider: ActionProvider<A>, viewRender: ViewRender<S>): Disposable
 }

--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/MVI.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/MVI.kt
@@ -7,7 +7,7 @@ interface ActionProvider<A> {
     val actions: Observable<A>
 }
 
-interface ViewRender<S> {
+interface Displayer<S> {
     fun render(state: S)
 }
 
@@ -21,5 +21,5 @@ interface Middleware<A, S, C> {
 
 interface Store<A, S, C> {
     fun wire(): Disposable
-    fun bind(actionProvider: ActionProvider<A>, viewRender: ViewRender<S>): Disposable
+    fun bind(actionProvider: ActionProvider<A>, displayer: Displayer<S>): Disposable
 }

--- a/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/MVI.kt
+++ b/ModelViewIntentSample/core/src/main/java/com/novoda/movies/mvi/search/MVI.kt
@@ -3,11 +3,8 @@ package com.novoda.movies.mvi.search
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 
-interface ActionProvider<A> {
+interface Displayer<A, S> {
     val actions: Observable<A>
-}
-
-interface Displayer<S> {
     fun render(state: S)
 }
 
@@ -21,5 +18,5 @@ interface Middleware<A, S, C> {
 
 interface Store<A, S, C> {
     fun wire(): Disposable
-    fun bind(actionProvider: ActionProvider<A>, displayer: Displayer<S>): Disposable
+    fun bind(displayer: Displayer<A, S>): Disposable
 }

--- a/ModelViewIntentSample/search/build.gradle
+++ b/ModelViewIntentSample/search/build.gradle
@@ -48,4 +48,5 @@ dependencies {
     testImplementation libraries.test.mockitoKotlin
     testImplementation libraries.test.mockitoInline
     testImplementation libraries.test.assertj
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
 }

--- a/ModelViewIntentSample/search/src/main/AndroidManifest.xml
+++ b/ModelViewIntentSample/search/src/main/AndroidManifest.xml
@@ -9,8 +9,7 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name=".presentation.SearchActivity"
-                  android:screenOrientation="portrait"/>
+        <activity android:name=".presentation.SearchActivity" />
     </application>
 
 </manifest>

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/data/ApiSearchResultsConverter.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/data/ApiSearchResultsConverter.kt
@@ -13,7 +13,6 @@ internal class ApiSearchResultsConverter(
         return apiSearchResults.toSearchResults()
     }
 
-
     private fun ApiSearchResults.toSearchResults(): SearchResults {
         return SearchResults(
             items = results.map {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/data/SearchBackend.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/data/SearchBackend.kt
@@ -3,18 +3,14 @@ package com.novoda.movies.mvi.search.data
 import com.novoda.movies.mvi.search.domain.SearchResults
 import io.reactivex.Single
 
-interface MovieDataSource {
-    fun search(query: String): Single<SearchResults>
-}
-
 internal class SearchBackend(
-    private val searchApi: SearchApi,
-    private val searchConverter: ApiSearchResultsConverter
-): MovieDataSource {
+        private val searchApi: SearchApi,
+        private val searchConverter: ApiSearchResultsConverter
+) {
 
-    override fun search(query: String): Single<SearchResults> {
+    fun search(query: String): Single<SearchResults> {
         return searchApi
-            .search(query)
-            .map(searchConverter::convert)
+                .search(query)
+                .map(searchConverter::convert)
     }
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/data/SearchBackend.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/data/SearchBackend.kt
@@ -3,12 +3,16 @@ package com.novoda.movies.mvi.search.data
 import com.novoda.movies.mvi.search.domain.SearchResults
 import io.reactivex.Single
 
+interface MovieDataSource {
+    fun search(query: String): Single<SearchResults>
+}
+
 internal class SearchBackend(
     private val searchApi: SearchApi,
     private val searchConverter: ApiSearchResultsConverter
-) {
+): MovieDataSource {
 
-    fun search(query: String): Single<SearchResults> {
+    override fun search(query: String): Single<SearchResults> {
         return searchApi
             .search(query)
             .map(searchConverter::convert)

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -9,6 +9,7 @@ import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchApi
 import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
+import com.novoda.movies.mvi.search.presentation.SearchStore
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 
 internal class SearchDependencyProvider(
@@ -24,7 +25,7 @@ internal class SearchDependencyProvider(
         )
     }
 
-    fun provideSearchStore(): BaseStore<SearchAction, SearchState, SearchChanges> {
+    fun provideSearchStore(): SearchStore {
         return BaseStore(
             reducer = SearchReducer(provideSearchResultsConverter()),
             schedulingStrategy = ProductionSchedulingStrategy(),

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -5,6 +5,7 @@ import com.novoda.movies.mvi.search.Endpoints
 import com.novoda.movies.mvi.search.NetworkDependencyProvider
 import com.novoda.movies.mvi.search.ProductionSchedulingStrategy
 import com.novoda.movies.mvi.search.data.ApiSearchResultsConverter
+import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchApi
 import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
@@ -15,7 +16,7 @@ internal class SearchDependencyProvider(
         private val endpoints: Endpoints
 ) {
 
-    private fun provideSearchBackend(): SearchBackend {
+    private fun provideMovieDataSource(): MovieDataSource {
         val searchApi = networkDependencyProvider.provideRetrofit().create(SearchApi::class.java)
         return SearchBackend(
                 searchApi,
@@ -27,7 +28,7 @@ internal class SearchDependencyProvider(
         return BaseStore(
             reducer = SearchReducer(provideSearchResultsConverter()),
             schedulingStrategy = ProductionSchedulingStrategy(),
-            middlewares = listOf(SearchMiddleware(provideSearchBackend(), ProductionSchedulingStrategy().work)),
+            middlewares = listOf(SearchMiddleware(provideMovieDataSource(), ProductionSchedulingStrategy().work)),
             initialValue = SearchState.Content(queryString = "", results = ViewSearchResults())
         )
     }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -8,9 +8,9 @@ import com.novoda.movies.mvi.search.data.ApiSearchResultsConverter
 import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchApi
 import com.novoda.movies.mvi.search.data.SearchBackend
-import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
 import com.novoda.movies.mvi.search.presentation.SearchStore
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.State
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 
 internal class SearchDependencyProvider(

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -8,6 +8,7 @@ import com.novoda.movies.mvi.search.data.ApiSearchResultsConverter
 import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchApi
 import com.novoda.movies.mvi.search.data.SearchBackend
+import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
 import com.novoda.movies.mvi.search.presentation.SearchStore
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
@@ -27,10 +28,10 @@ internal class SearchDependencyProvider(
 
     fun provideSearchStore(): SearchStore {
         return BaseStore(
-            reducer = SearchReducer(provideSearchResultsConverter()),
-            schedulingStrategy = ProductionSchedulingStrategy(),
-            middlewares = listOf(SearchMiddleware(provideMovieDataSource(), ProductionSchedulingStrategy().work)),
-            initialValue = ScreenState(queryString = "", results = ViewSearchResults.emptyResults)
+                reducer = SearchReducer(provideSearchResultsConverter()),
+                schedulingStrategy = ProductionSchedulingStrategy(),
+                middlewares = listOf(SearchMiddleware(provideMovieDataSource(), ProductionSchedulingStrategy().work)),
+                initialValue = State(queryString = "", results = ViewSearchResults.emptyResults)
         )
     }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchDependencyProvider.kt
@@ -5,7 +5,6 @@ import com.novoda.movies.mvi.search.Endpoints
 import com.novoda.movies.mvi.search.NetworkDependencyProvider
 import com.novoda.movies.mvi.search.ProductionSchedulingStrategy
 import com.novoda.movies.mvi.search.data.ApiSearchResultsConverter
-import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchApi
 import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
@@ -18,7 +17,7 @@ internal class SearchDependencyProvider(
         private val endpoints: Endpoints
 ) {
 
-    private fun provideMovieDataSource(): MovieDataSource {
+    private fun provideSearchBackend(): SearchBackend {
         val searchApi = networkDependencyProvider.provideRetrofit().create(SearchApi::class.java)
         return SearchBackend(
                 searchApi,
@@ -30,7 +29,7 @@ internal class SearchDependencyProvider(
         return BaseStore(
                 reducer = SearchReducer(provideSearchResultsConverter()),
                 schedulingStrategy = ProductionSchedulingStrategy(),
-                middlewares = listOf(SearchMiddleware(provideMovieDataSource(), ProductionSchedulingStrategy().work)),
+                middlewares = listOf(SearchMiddleware(provideSearchBackend(), ProductionSchedulingStrategy().work)),
                 initialValue = State(queryString = "", results = ViewSearchResults.emptyResults)
         )
     }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -1,6 +1,7 @@
 package com.novoda.movies.mvi.search.domain
 
 import com.novoda.movies.mvi.search.Middleware
+import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.domain.SearchChanges.*
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
@@ -10,7 +11,7 @@ import io.reactivex.functions.BiFunction
 
 
 internal class SearchMiddleware(
-        private val backend: SearchBackend,
+        private val dataSource: MovieDataSource,
         private val workScheduler: Scheduler
 ) : Middleware<SearchAction, SearchState, SearchChanges> {
 
@@ -31,7 +32,7 @@ internal class SearchMiddleware(
             }
 
     private fun processAction(state: SearchState): Observable<SearchChanges> {
-        return backend.search(state.queryString)
+        return dataSource.search(state.queryString)
                 .toObservable()
                 .map { searchResult -> SearchCompleted(searchResult) as SearchChanges }
                 .startWith(SearchInProgress)

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -1,7 +1,7 @@
 package com.novoda.movies.mvi.search.domain
 
 import com.novoda.movies.mvi.search.Middleware
-import com.novoda.movies.mvi.search.data.MovieDataSource
+import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes.*
 import com.novoda.movies.mvi.search.presentation.SearchViewModel
@@ -12,7 +12,7 @@ import io.reactivex.Scheduler
 import io.reactivex.functions.BiFunction
 
 internal class SearchMiddleware(
-        private val dataSource: MovieDataSource,
+        private val dataSource: SearchBackend,
         private val workScheduler: Scheduler
 ) : Middleware<SearchViewModel.Action, State, Changes> {
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -12,7 +12,7 @@ import io.reactivex.Scheduler
 import io.reactivex.functions.BiFunction
 
 internal class SearchMiddleware(
-        private val dataSource: SearchBackend,
+        private val backend: SearchBackend,
         private val workScheduler: Scheduler
 ) : Middleware<SearchViewModel.Action, State, Changes> {
 
@@ -39,7 +39,7 @@ internal class SearchMiddleware(
     }
 
     private fun processAction(state: State): Observable<Changes> {
-        val loadContent = dataSource.search(state.queryString)
+        val loadContent = backend.search(state.queryString)
                 .toObservable()
                 .map { searchResult -> AddResults(searchResult) as Changes }
                 .startWith(ShowProgress)

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -5,6 +5,7 @@ import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes.*
 import com.novoda.movies.mvi.search.presentation.SearchActivity.Action
+import com.novoda.movies.mvi.search.presentation.SearchActivity.Action.*
 import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import io.reactivex.Observable
 import io.reactivex.Scheduler
@@ -27,9 +28,9 @@ internal class SearchMiddleware(
 
     private fun handle(action: Action, state: State): Observable<Changes> =
             when (action) {
-                is Action.ChangeQuery -> Observable.just(UpdateSearchQuery(action.queryString))
-                is Action.ExecuteSearch -> processAction(state)
-                is Action.ClearQuery -> processClearQuery()
+                is ChangeQuery -> Observable.just(UpdateSearchQuery(action.queryString))
+                is ExecuteSearch -> processAction(state)
+                is ClearQuery -> processClearQuery()
             }
 
     private fun processClearQuery(): Observable<Changes> {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchMiddleware.kt
@@ -4,29 +4,28 @@ import com.novoda.movies.mvi.search.Middleware
 import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes.*
-import com.novoda.movies.mvi.search.presentation.SearchActivity.Action
-import com.novoda.movies.mvi.search.presentation.SearchActivity.Action.*
-import com.novoda.movies.mvi.search.presentation.SearchActivity.State
+import com.novoda.movies.mvi.search.presentation.SearchViewModel
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.Action.*
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.State
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.functions.BiFunction
 
-
 internal class SearchMiddleware(
         private val dataSource: MovieDataSource,
         private val workScheduler: Scheduler
-) : Middleware<Action, State, Changes> {
+) : Middleware<SearchViewModel.Action, State, Changes> {
 
-    override fun bind(actions: Observable<Action>, state: Observable<State>): Observable<Changes> {
+    override fun bind(actions: Observable<SearchViewModel.Action>, state: Observable<State>): Observable<Changes> {
         return actions
                 .withLatestFrom(state, actionToState())
                 .switchMap { (action, state) -> handle(action, state) }
     }
 
-    private fun actionToState(): BiFunction<Action, State, Pair<Action, State>> =
+    private fun actionToState(): BiFunction<SearchViewModel.Action, State, Pair<SearchViewModel.Action, State>> =
             BiFunction { action, state -> action to state }
 
-    private fun handle(action: Action, state: State): Observable<Changes> =
+    private fun handle(action: SearchViewModel.Action, state: State): Observable<Changes> =
             when (action) {
                 is ChangeQuery -> Observable.just(UpdateSearchQuery(action.queryString))
                 is ExecuteSearch -> processAction(state)

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
@@ -1,61 +1,56 @@
 package com.novoda.movies.mvi.search.domain
 
 import com.novoda.movies.mvi.search.Reducer
+import com.novoda.movies.mvi.search.domain.SearchReducer.Changes.*
+import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 
 internal class SearchReducer(
-    private val searchResultsConverter: SearchResultsConverter
-) : Reducer<ScreenState, ScreenStateChanges> {
+        private val searchResultsConverter: SearchResultsConverter
+) : Reducer<State, SearchReducer.Changes> {
 
-    override fun reduce(state: ScreenState, change: ScreenStateChanges): ScreenState =
-        when (change) {
-            is ScreenStateChanges.ShowProgress -> state.showLoading()
-            is ScreenStateChanges.HideProgress -> state.hideLoading()
-            is ScreenStateChanges.AddResults -> state.addResults(change.results)
-            is ScreenStateChanges.RemoveResults -> state.removeResults()
-            is ScreenStateChanges.UpdateSearchQuery -> state.updateQuery(change.queryString)
-            is ScreenStateChanges.HandleError -> state.toError(change.throwable)
-        }
+    override fun reduce(state: State, change: Changes): State =
+            when (change) {
+                is ShowProgress -> state.showLoading()
+                is HideProgress -> state.hideLoading()
+                is AddResults -> state.addResults(change.results)
+                is RemoveResults -> state.removeResults()
+                is UpdateSearchQuery -> state.updateQuery(change.queryString)
+                is HandleError -> state.toError(change.throwable)
+            }
 
-    private fun ScreenState.addResults(results: SearchResults): ScreenState {
+    private fun State.addResults(results: SearchResults): State {
         return copy(results = searchResultsConverter.convert(results))
     }
+
+    sealed class Changes {
+        object ShowProgress : Changes()
+        object HideProgress : Changes()
+        data class AddResults(val results: SearchResults) : Changes()
+        object RemoveResults : Changes()
+        data class HandleError(val throwable: Throwable) : Changes()
+        data class UpdateSearchQuery(val queryString: String) : Changes()
+    }
+
 }
 
-private fun ScreenState.removeResults(): ScreenState {
+private fun State.removeResults(): State {
     return copy(results = ViewSearchResults.emptyResults)
 }
 
-private fun ScreenState.toError(throwable: Throwable): ScreenState {
+private fun State.toError(throwable: Throwable): State {
     return copy(error = throwable)
 }
 
-private fun ScreenState.updateQuery(queryString: String): ScreenState {
+private fun State.updateQuery(queryString: String): State {
     return copy(queryString = queryString)
 }
 
-private fun ScreenState.hideLoading(): ScreenState {
+private fun State.hideLoading(): State {
     return copy(loading = false)
 }
 
-private fun ScreenState.showLoading(): ScreenState {
+private fun State.showLoading(): State {
     return copy(loading = true)
-}
-
-internal data class ScreenState(
-    var queryString: String,
-    var loading: Boolean = false,
-    var results: ViewSearchResults,
-    var error: Throwable? = null
-)
-
-sealed class ScreenStateChanges {
-
-    object ShowProgress : ScreenStateChanges()
-    object HideProgress : ScreenStateChanges()
-    data class AddResults(val results: SearchResults) : ScreenStateChanges()
-    object RemoveResults: ScreenStateChanges()
-    data class HandleError(val throwable: Throwable) : ScreenStateChanges()
-    data class UpdateSearchQuery(val queryString: String) : ScreenStateChanges()
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/domain/SearchReducer.kt
@@ -2,8 +2,8 @@ package com.novoda.movies.mvi.search.domain
 
 import com.novoda.movies.mvi.search.Reducer
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes.*
-import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import com.novoda.movies.mvi.search.presentation.SearchResultsConverter
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.State
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 
 internal class SearchReducer(

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -3,10 +3,7 @@ package com.novoda.movies.mvi.search.presentation
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
-import com.novoda.movies.mvi.search.BaseStore
-import com.novoda.movies.mvi.search.Dependencies
-import com.novoda.movies.mvi.search.MVIView
-import com.novoda.movies.mvi.search.R
+import com.novoda.movies.mvi.search.*
 import com.novoda.movies.mvi.search.domain.SearchAction
 import com.novoda.movies.mvi.search.domain.SearchChanges
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
@@ -15,7 +12,9 @@ import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.activity_search.*
 
-internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, SearchState> {
+internal class SearchActivity : AppCompatActivity(),
+        ActionProvider<SearchAction>,
+        ViewRender<SearchState> {
 
     private lateinit var searchInput: SearchInputView
     private lateinit var resultsView: SearchResultsView
@@ -27,6 +26,7 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Searc
 
     private var wireDisposable: Disposable? = null
     private var bindDisposable: Disposable? = null
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,7 +40,7 @@ internal class SearchActivity : AppCompatActivity(), MVIView<SearchAction, Searc
 
     override fun onStart() {
         super.onStart()
-        bindDisposable = searchStore.bind(this)
+        bindDisposable = searchStore.bind(actionProvider = this, viewRender = this)
     }
 
     override fun render(state: SearchState) {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -10,8 +10,8 @@ import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.Dependencies
-import com.novoda.movies.mvi.search.R
 import com.novoda.movies.mvi.search.Displayer
+import com.novoda.movies.mvi.search.R
 import com.novoda.movies.mvi.search.domain.ScreenState
 import com.novoda.movies.mvi.search.domain.SearchAction
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
@@ -37,8 +37,6 @@ internal class SearchActivity : AppCompatActivity(),
         setContentView(R.layout.activity_search)
         searchInput = search_input
         resultsView = search_results
-
-        viewModel.wire()
     }
 
     override fun onStart() {
@@ -59,11 +57,6 @@ internal class SearchActivity : AppCompatActivity(),
     override fun onStop() {
         viewModel.unbind()
         super.onStop()
-    }
-
-    override fun onDestroy() {
-        viewModel.unwire()
-        super.onDestroy()
     }
 }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -11,7 +11,7 @@ import android.view.View.VISIBLE
 import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.R
-import com.novoda.movies.mvi.search.ViewRender
+import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.domain.ScreenState
 import com.novoda.movies.mvi.search.domain.SearchAction
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
@@ -20,7 +20,7 @@ import kotlinx.android.synthetic.main.activity_search.*
 
 internal class SearchActivity : AppCompatActivity(),
         ActionProvider<SearchAction>,
-        ViewRender<ScreenState> {
+        Displayer<ScreenState> {
 
     private lateinit var searchInput: SearchInputView
     private lateinit var resultsView: SearchResultsView

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.view.View
+import android.view.View.*
 import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.R
@@ -14,6 +15,7 @@ import com.novoda.movies.mvi.search.ViewRender
 import com.novoda.movies.mvi.search.domain.SearchAction
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
 import com.novoda.movies.mvi.search.domain.SearchState
+import com.novoda.movies.mvi.search.domain.SearchState.*
 import io.reactivex.Observable
 import kotlinx.android.synthetic.main.activity_search.*
 
@@ -47,17 +49,13 @@ internal class SearchActivity : AppCompatActivity(),
 
     override fun render(state: SearchState) {
         when (state) {
-            is SearchState.Content -> {
-                searchInput.currentQuery = state.queryString
+            is Content -> {
                 resultsView.showResults(state.results)
-                loading_spinner.visibility = View.INVISIBLE
             }
-
-            is SearchState.Loading -> loading_spinner.visibility = View.VISIBLE
-            is SearchState.Error -> loading_spinner.visibility = View.VISIBLE
-            //TODO: Handle Error
         }
-        Log.v("APP", "state: $state")
+
+        error_view.visibility = if (state is Error) VISIBLE else INVISIBLE
+        loading_spinner.visibility = if (state is Loading) VISIBLE else INVISIBLE
     }
 
     override fun onStop() {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -6,6 +6,7 @@ import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import android.view.View
 import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.R
@@ -49,9 +50,11 @@ internal class SearchActivity : AppCompatActivity(),
             is SearchState.Content -> {
                 searchInput.currentQuery = state.queryString
                 resultsView.showResults(state.results)
+                loading_spinner.visibility = View.INVISIBLE
             }
 
-            //TODO: Handle Loading
+            is SearchState.Loading -> loading_spinner.visibility = View.VISIBLE
+            is SearchState.Error -> loading_spinner.visibility = View.VISIBLE
             //TODO: Handle Error
         }
         Log.v("APP", "state: $state")

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -50,6 +50,9 @@ internal class SearchActivity : AppCompatActivity(),
     override fun render(state: SearchState) {
         when (state) {
             is Content -> {
+                if (searchInput.currentQuery != state.queryString) {
+                    searchInput.currentQuery = state.queryString
+                }
                 resultsView.showResults(state.results)
             }
         }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -11,21 +11,20 @@ import android.view.View.VISIBLE
 import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.R
-import com.novoda.movies.mvi.search.domain.ScreenState
-import com.novoda.movies.mvi.search.domain.SearchAction
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
+import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import io.reactivex.Observable
 import kotlinx.android.synthetic.main.activity_search.*
 
 internal class SearchActivity : AppCompatActivity(),
-        Displayer<SearchAction, ScreenState> {
+        Displayer<SearchActivity.Action, State> {
 
     private lateinit var searchInput: SearchInputView
     private lateinit var resultsView: SearchResultsView
 
     private lateinit var viewModel: SearchViewModel
 
-    override val actions: Observable<SearchAction>
+    override val actions: Observable<Action>
         get() = searchInput.actions
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,7 +41,7 @@ internal class SearchActivity : AppCompatActivity(),
         viewModel.bind(this)
     }
 
-    override fun render(state: ScreenState) {
+    override fun render(state: State) {
         searchInput.currentQuery = state.queryString
         resultsView.showResults(state.results)
         error_view.visibility = if (state.error != null) VISIBLE else INVISIBLE
@@ -55,6 +54,19 @@ internal class SearchActivity : AppCompatActivity(),
     override fun onStop() {
         viewModel.unbind()
         super.onStop()
+    }
+
+    internal data class State(
+            var queryString: String,
+            var loading: Boolean = false,
+            var results: ViewSearchResults,
+            var error: Throwable? = null
+    )
+
+    internal sealed class Action {
+        data class ChangeQuery(val queryString: String) : Action()
+        object ExecuteSearch : Action()
+        object ClearQuery : Action()
     }
 }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -12,12 +12,13 @@ import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.R
 import com.novoda.movies.mvi.search.domain.SearchDependencyProvider
-import com.novoda.movies.mvi.search.presentation.SearchActivity.State
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.Action
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.State
 import io.reactivex.Observable
 import kotlinx.android.synthetic.main.activity_search.*
 
 internal class SearchActivity : AppCompatActivity(),
-        Displayer<SearchActivity.Action, State> {
+        Displayer<Action, State> {
 
     private lateinit var searchInput: SearchInputView
     private lateinit var resultsView: SearchResultsView
@@ -54,19 +55,6 @@ internal class SearchActivity : AppCompatActivity(),
     override fun onStop() {
         viewModel.unbind()
         super.onStop()
-    }
-
-    internal data class State(
-            var queryString: String,
-            var loading: Boolean = false,
-            var results: ViewSearchResults,
-            var error: Throwable? = null
-    )
-
-    internal sealed class Action {
-        data class ChangeQuery(val queryString: String) : Action()
-        object ExecuteSearch : Action()
-        object ClearQuery : Action()
     }
 }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchActivity.kt
@@ -8,7 +8,6 @@ import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
-import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.Dependencies
 import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.R
@@ -19,8 +18,7 @@ import io.reactivex.Observable
 import kotlinx.android.synthetic.main.activity_search.*
 
 internal class SearchActivity : AppCompatActivity(),
-        ActionProvider<SearchAction>,
-        Displayer<ScreenState> {
+        Displayer<SearchAction, ScreenState> {
 
     private lateinit var searchInput: SearchInputView
     private lateinit var resultsView: SearchResultsView
@@ -41,7 +39,7 @@ internal class SearchActivity : AppCompatActivity(),
 
     override fun onStart() {
         super.onStart()
-        viewModel.bind(this, this)
+        viewModel.bind(this)
     }
 
     override fun render(state: ScreenState) {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchInputView.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchInputView.kt
@@ -15,7 +15,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
 import com.novoda.movies.mvi.search.R
-import com.novoda.movies.mvi.search.domain.SearchAction
+import com.novoda.movies.mvi.search.presentation.SearchActivity.Action
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.search_bar.view.*
@@ -29,7 +29,7 @@ internal class SearchInputView @JvmOverloads constructor(
     private lateinit var searchInput: EditText
     private lateinit var clearTextButton: View
 
-    private val actionStream: PublishSubject<SearchAction> = PublishSubject.create()
+    private val actionStream: PublishSubject<Action> = PublishSubject.create()
 
     var currentQuery: String
         get() = searchInput.text.toString()
@@ -38,7 +38,7 @@ internal class SearchInputView @JvmOverloads constructor(
             searchInput.setSelection(text.length)
         }
 
-    val actions: Observable<SearchAction>
+    val actions: Observable<Action>
         get() = actionStream
 
     private fun showKeyboard() {
@@ -60,7 +60,7 @@ internal class SearchInputView @JvmOverloads constructor(
         searchInput.isSaveEnabled = false
         searchInput.setOnEditorActionListener { inputView, actionId, keyEvent ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH || enterKeyPressed(keyEvent)) {
-                actionStream.onNext(SearchAction.ExecuteSearch)
+                actionStream.onNext(Action.ExecuteSearch)
                 inputView.hideKeyboard()
                 inputView.clearFocus()
                 return@setOnEditorActionListener true
@@ -72,7 +72,7 @@ internal class SearchInputView @JvmOverloads constructor(
     }
 
     private fun clearText() {
-        actionStream.onNext(SearchAction.ClearQuery)
+        actionStream.onNext(Action.ClearQuery)
     }
 
     private fun enterKeyPressed(keyEvent: KeyEvent?): Boolean {
@@ -84,7 +84,7 @@ internal class SearchInputView @JvmOverloads constructor(
     private val textChangedListener = object :
             AfterTextChangedWatcher {
         override fun afterTextChanged(text: Editable) {
-            actionStream.onNext(SearchAction.ChangeQuery(text.toString()))
+            actionStream.onNext(Action.ChangeQuery(text.toString()))
 
             val showClear = text.isNotEmpty()
             clearTextButton.visibility = if (showClear) View.VISIBLE else View.GONE

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchInputView.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchInputView.kt
@@ -15,7 +15,8 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
 import com.novoda.movies.mvi.search.R
-import com.novoda.movies.mvi.search.presentation.SearchActivity.Action
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.Action
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.Action.*
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.search_bar.view.*
@@ -60,7 +61,7 @@ internal class SearchInputView @JvmOverloads constructor(
         searchInput.isSaveEnabled = false
         searchInput.setOnEditorActionListener { inputView, actionId, keyEvent ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH || enterKeyPressed(keyEvent)) {
-                actionStream.onNext(Action.ExecuteSearch)
+                actionStream.onNext(ExecuteSearch)
                 inputView.hideKeyboard()
                 inputView.clearFocus()
                 return@setOnEditorActionListener true
@@ -72,7 +73,7 @@ internal class SearchInputView @JvmOverloads constructor(
     }
 
     private fun clearText() {
-        actionStream.onNext(Action.ClearQuery)
+        actionStream.onNext(ClearQuery)
     }
 
     private fun enterKeyPressed(keyEvent: KeyEvent?): Boolean {
@@ -84,7 +85,7 @@ internal class SearchInputView @JvmOverloads constructor(
     private val textChangedListener = object :
             AfterTextChangedWatcher {
         override fun afterTextChanged(text: Editable) {
-            actionStream.onNext(Action.ChangeQuery(text.toString()))
+            actionStream.onNext(ChangeQuery(text.toString()))
 
             val showClear = text.isNotEmpty()
             clearTextButton.visibility = if (showClear) View.VISIBLE else View.GONE

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -26,5 +26,3 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
 
     fun unbind() = bindDisposable?.dispose()
 }
-
-

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -3,7 +3,7 @@ package com.novoda.movies.mvi.search.presentation
 import android.arch.lifecycle.ViewModel
 import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.BaseStore
-import com.novoda.movies.mvi.search.ViewRender
+import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.domain.ScreenState
 import com.novoda.movies.mvi.search.domain.ScreenStateChanges
 import com.novoda.movies.mvi.search.domain.SearchAction
@@ -16,8 +16,8 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
     private var wireDisposable: Disposable? = null
     private var bindDisposable: Disposable? = null
 
-    fun bind(actionProvider: ActionProvider<SearchAction>, viewRender: ViewRender<ScreenState>) {
-        bindDisposable = store.bind(actionProvider = actionProvider, viewRender = viewRender)
+    fun bind(actionProvider: ActionProvider<SearchAction>, displayer: Displayer<ScreenState>) {
+        bindDisposable = store.bind(actionProvider = actionProvider, displayer = displayer)
     }
 
     fun wire() {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -3,12 +3,12 @@ package com.novoda.movies.mvi.search.presentation
 import android.arch.lifecycle.ViewModel
 import com.novoda.movies.mvi.search.BaseStore
 import com.novoda.movies.mvi.search.Displayer
-import com.novoda.movies.mvi.search.domain.ScreenState
 import com.novoda.movies.mvi.search.domain.ScreenStateChanges
-import com.novoda.movies.mvi.search.domain.SearchAction
+import com.novoda.movies.mvi.search.presentation.SearchActivity.Action
+import com.novoda.movies.mvi.search.presentation.SearchActivity.State
 import io.reactivex.disposables.Disposable
 
-internal typealias SearchStore = BaseStore<SearchAction, ScreenState, ScreenStateChanges>
+internal typealias SearchStore = BaseStore<Action, State, ScreenStateChanges>
 
 internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
 
@@ -19,7 +19,7 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
         wireDisposable = store.wire()
     }
 
-    fun bind(displayer: Displayer<SearchAction, ScreenState>) {
+    fun bind(displayer: Displayer<Action, State>) {
         bindDisposable = store.bind(displayer = displayer)
     }
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -3,23 +3,17 @@ package com.novoda.movies.mvi.search.presentation
 import android.arch.lifecycle.ViewModel
 import com.novoda.movies.mvi.search.BaseStore
 import com.novoda.movies.mvi.search.Displayer
-import com.novoda.movies.mvi.search.domain.ScreenStateChanges
-import com.novoda.movies.mvi.search.presentation.SearchActivity.Action
-import com.novoda.movies.mvi.search.presentation.SearchActivity.State
+import com.novoda.movies.mvi.search.domain.SearchReducer
 import io.reactivex.disposables.Disposable
 
-internal typealias SearchStore = BaseStore<Action, State, ScreenStateChanges>
+internal typealias SearchStore = BaseStore<SearchActivity.Action, SearchActivity.State, SearchReducer.Changes>
+internal typealias SearchDisplayer = Displayer<SearchActivity.Action, SearchActivity.State>
 
 internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
-
-    private var wireDisposable: Disposable? = null
+    private val wireDisposable = store.wire()
     private var bindDisposable: Disposable? = null
 
-    init {
-        wireDisposable = store.wire()
-    }
-
-    fun bind(displayer: Displayer<Action, State>) {
+    fun bind(displayer: SearchDisplayer) {
         bindDisposable = store.bind(displayer = displayer)
     }
 
@@ -27,7 +21,7 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
         super.onCleared()
 
         unbind()
-        wireDisposable?.dispose()
+        wireDisposable.dispose()
     }
 
     fun unbind() = bindDisposable?.dispose()

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -6,8 +6,8 @@ import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.domain.SearchReducer
 import io.reactivex.disposables.Disposable
 
-internal typealias SearchStore = BaseStore<SearchActivity.Action, SearchActivity.State, SearchReducer.Changes>
-internal typealias SearchDisplayer = Displayer<SearchActivity.Action, SearchActivity.State>
+internal typealias SearchStore = BaseStore<SearchViewModel.Action, SearchViewModel.State, SearchReducer.Changes>
+internal typealias SearchDisplayer = Displayer<SearchViewModel.Action, SearchViewModel.State>
 
 internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
     private val wireDisposable = store.wire()
@@ -25,4 +25,17 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
     }
 
     fun unbind() = bindDisposable?.dispose()
+
+    internal data class State(
+            var queryString: String,
+            var loading: Boolean = false,
+            var results: ViewSearchResults,
+            var error: Throwable? = null
+    )
+
+    internal sealed class Action {
+        data class ChangeQuery(val queryString: String) : Action()
+        object ExecuteSearch : Action()
+        object ClearQuery : Action()
+    }
 }

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -16,16 +16,22 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
     private var wireDisposable: Disposable? = null
     private var bindDisposable: Disposable? = null
 
+    init {
+        wireDisposable = store.wire()
+    }
+
     fun bind(actionProvider: ActionProvider<SearchAction>, displayer: Displayer<ScreenState>) {
         bindDisposable = store.bind(actionProvider = actionProvider, displayer = displayer)
     }
 
-    fun wire() {
-        wireDisposable = store.wire()
+    override fun onCleared() {
+        super.onCleared()
+
+        unbind()
+        wireDisposable?.dispose()
     }
 
     fun unbind() = bindDisposable?.dispose()
-    fun unwire() = wireDisposable?.dispose()
 }
 
 

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -1,7 +1,6 @@
 package com.novoda.movies.mvi.search.presentation
 
 import android.arch.lifecycle.ViewModel
-import com.novoda.movies.mvi.search.ActionProvider
 import com.novoda.movies.mvi.search.BaseStore
 import com.novoda.movies.mvi.search.Displayer
 import com.novoda.movies.mvi.search.domain.ScreenState
@@ -20,8 +19,8 @@ internal class SearchViewModel(private val store: SearchStore) : ViewModel() {
         wireDisposable = store.wire()
     }
 
-    fun bind(actionProvider: ActionProvider<SearchAction>, displayer: Displayer<ScreenState>) {
-        bindDisposable = store.bind(actionProvider = actionProvider, displayer = displayer)
+    fun bind(displayer: Displayer<SearchAction, ScreenState>) {
+        bindDisposable = store.bind(displayer = displayer)
     }
 
     override fun onCleared() {

--- a/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
+++ b/ModelViewIntentSample/search/src/main/java/com/novoda/movies/mvi/search/presentation/SearchViewModel.kt
@@ -1,0 +1,31 @@
+package com.novoda.movies.mvi.search.presentation
+
+import android.arch.lifecycle.ViewModel
+import com.novoda.movies.mvi.search.ActionProvider
+import com.novoda.movies.mvi.search.BaseStore
+import com.novoda.movies.mvi.search.ViewRender
+import com.novoda.movies.mvi.search.domain.SearchAction
+import com.novoda.movies.mvi.search.domain.SearchChanges
+import com.novoda.movies.mvi.search.domain.SearchState
+import io.reactivex.disposables.Disposable
+
+internal typealias SearchStore = BaseStore<SearchAction, SearchState, SearchChanges>
+
+internal class SearchViewModel(private val store: SearchStore): ViewModel() {
+
+    private var wireDisposable: Disposable? = null
+    private var bindDisposable: Disposable? = null
+
+    fun bind(actionProvider: ActionProvider<SearchAction>, viewRender: ViewRender<SearchState>) {
+        bindDisposable = store.bind(actionProvider = actionProvider, viewRender = viewRender)
+    }
+
+    fun wire() {
+        wireDisposable = store.wire()
+    }
+
+    fun unbind() = bindDisposable?.dispose()
+    fun unwire() = wireDisposable?.dispose()
+}
+
+

--- a/ModelViewIntentSample/search/src/main/res/layout/activity_search.xml
+++ b/ModelViewIntentSample/search/src/main/res/layout/activity_search.xml
@@ -21,8 +21,8 @@
                 android:layout_height="44dp"
                 android:focusable="true"
                 android:focusableInTouchMode="true"/>
-
     </android.support.v7.widget.Toolbar>
+
 
     <com.novoda.movies.mvi.search.presentation.SearchResultsView
             android:id="@+id/search_results"
@@ -33,6 +33,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar"/>
 
+    <ProgressBar
+        android:indeterminate="true"
+        android:layout_width="wrap_content"
+        android:id="@+id/loading_spinner"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </android.support.constraint.ConstraintLayout>
 
 

--- a/ModelViewIntentSample/search/src/main/res/layout/activity_search.xml
+++ b/ModelViewIntentSample/search/src/main/res/layout/activity_search.xml
@@ -33,6 +33,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar"/>
 
+    <TextView
+        android:id="@+id/error_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        android:text="@string/movies_error"/>
+
     <ProgressBar
         android:indeterminate="true"
         android:layout_width="wrap_content"

--- a/ModelViewIntentSample/search/src/main/res/values/strings.xml
+++ b/ModelViewIntentSample/search/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Search</string>
     <string name="search_no_results_description">No Results found for \"%s\"</string>
+    <string name="movies_error">There was an error fetching the movies</string>
 </resources>

--- a/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
+++ b/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
@@ -17,8 +17,8 @@ import org.junit.Test
 
 class SearchMiddlewareTest {
 
-    private val dataSource: SearchBackend = mock()
-    private val searchMiddleware = SearchMiddleware(dataSource, Schedulers.trampoline())
+    private val backend: SearchBackend = mock()
+    private val searchMiddleware = SearchMiddleware(backend, Schedulers.trampoline())
 
     private val actions = PublishSubject.create<Action>()
     private val state = PublishSubject.create<State>()
@@ -54,7 +54,7 @@ class SearchMiddlewareTest {
     fun `GIVEN dataSource has results WHEN execute search THEN search is in progress AND search is completed`() {
         val searchResults = SearchResults(items = listOf())
         state.onNext(State(queryString = "iron man", results = ViewSearchResults.emptyResults))
-        dataSource.stub { on { search("iron man") } doReturn Single.just(searchResults) }
+        backend.stub { on { search("iron man") } doReturn Single.just(searchResults) }
 
         actions.onNext(Action.ExecuteSearch)
 
@@ -69,7 +69,7 @@ class SearchMiddlewareTest {
     fun `GIVEN dataSource errors WHEN execute search THEN search is in progress AND search failed`() {
         val exception = Throwable()
         state.onNext(State(queryString = "iron man", results = ViewSearchResults.emptyResults))
-        dataSource.stub { on { search("iron man") } doReturn (Single.error(exception)) }
+        backend.stub { on { search("iron man") } doReturn (Single.error(exception)) }
 
         actions.onNext(Action.ExecuteSearch)
 

--- a/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
+++ b/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
@@ -3,6 +3,7 @@ package com.novoda.movies.mvi.search.domain
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.stub
+import com.novoda.movies.mvi.search.data.MovieDataSource
 import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 import io.reactivex.Single
@@ -14,8 +15,8 @@ import org.junit.Test
 
 class SearchMiddlewareTest {
 
-    private val backend: SearchBackend = mock()
-    private val searchMiddleware = SearchMiddleware(backend, Schedulers.trampoline())
+    private val dataSource: MovieDataSource = mock()
+    private val searchMiddleware = SearchMiddleware(dataSource, Schedulers.trampoline())
 
     private val actions = PublishSubject.create<SearchAction>()
     private val state = PublishSubject.create<SearchState>()
@@ -45,10 +46,10 @@ class SearchMiddlewareTest {
     }
 
     @Test
-    fun `GIVEN backend has results WHEN execute search THEN search is in progress AND search is completed`() {
+    fun `GIVEN dataSource has results WHEN execute search THEN search is in progress AND search is completed`() {
         val searchResults = SearchResults(items = listOf())
         state.onNext(SearchState.Content(queryString = "iron man", results = ViewSearchResults()))
-        backend.stub { on { search("iron man") } doReturn Single.just(searchResults) }
+        dataSource.stub { on { search("iron man") } doReturn Single.just(searchResults) }
 
         actions.onNext(SearchAction.ExecuteSearch)
 
@@ -59,10 +60,10 @@ class SearchMiddlewareTest {
     }
 
     @Test
-    fun `GIVEN backend errors WHEN execute search THEN search is in progress AND search failed`() {
-        val exception = IllegalStateException("backend is down")
+    fun `GIVEN dataSource errors WHEN execute search THEN search is in progress AND search failed`() {
+        val exception = Throwable()
         state.onNext(SearchState.Content(queryString = "iron man", results = ViewSearchResults()))
-        backend.stub { on { search("iron man") } doReturn (Single.error(exception)) }
+        dataSource.stub { on { search("iron man") } doReturn (Single.error(exception)) }
 
         actions.onNext(SearchAction.ExecuteSearch)
 

--- a/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
+++ b/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
@@ -3,7 +3,7 @@ package com.novoda.movies.mvi.search.domain
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.stub
-import com.novoda.movies.mvi.search.data.MovieDataSource
+import com.novoda.movies.mvi.search.data.SearchBackend
 import com.novoda.movies.mvi.search.domain.SearchReducer.Changes
 import com.novoda.movies.mvi.search.presentation.SearchViewModel.Action
 import com.novoda.movies.mvi.search.presentation.SearchViewModel.State
@@ -17,7 +17,7 @@ import org.junit.Test
 
 class SearchMiddlewareTest {
 
-    private val dataSource: MovieDataSource = mock()
+    private val dataSource: SearchBackend = mock()
     private val searchMiddleware = SearchMiddleware(dataSource, Schedulers.trampoline())
 
     private val actions = PublishSubject.create<Action>()

--- a/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
+++ b/ModelViewIntentSample/search/src/test/java/com/novoda/movies/mvi/search/domain/SearchMiddlewareTest.kt
@@ -4,7 +4,9 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.stub
 import com.novoda.movies.mvi.search.data.MovieDataSource
-import com.novoda.movies.mvi.search.data.SearchBackend
+import com.novoda.movies.mvi.search.domain.SearchReducer.Changes
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.Action
+import com.novoda.movies.mvi.search.presentation.SearchViewModel.State
 import com.novoda.movies.mvi.search.presentation.ViewSearchResults
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver
@@ -18,9 +20,9 @@ class SearchMiddlewareTest {
     private val dataSource: MovieDataSource = mock()
     private val searchMiddleware = SearchMiddleware(dataSource, Schedulers.trampoline())
 
-    private val actions = PublishSubject.create<SearchAction>()
-    private val state = PublishSubject.create<ScreenState>()
-    private lateinit var changes: TestObserver<ScreenStateChanges>
+    private val actions = PublishSubject.create<Action>()
+    private val state = PublishSubject.create<State>()
+    private lateinit var changes: TestObserver<Changes>
 
     @Before
     fun setUp() {
@@ -29,52 +31,52 @@ class SearchMiddlewareTest {
 
     @Test
     fun `GIVEN state with query WHEN query changed THEN query is updated`() {
-        state.onNext(ScreenState(queryString = "iron man", results = ViewSearchResults.emptyResults))
+        state.onNext(State(queryString = "iron man", results = ViewSearchResults.emptyResults))
 
-        actions.onNext(SearchAction.ChangeQuery(queryString = "superman"))
+        actions.onNext(Action.ChangeQuery(queryString = "superman"))
 
-        changes.assertValue(ScreenStateChanges.UpdateSearchQuery("superman"))
+        changes.assertValue(Changes.UpdateSearchQuery("superman"))
     }
 
     @Test
     fun `WHEN query cleared THEN updated query is empty AND results are removed`() {
-        state.onNext(ScreenState(queryString = "iron man", results = ViewSearchResults.emptyResults))
+        state.onNext(State(queryString = "iron man", results = ViewSearchResults.emptyResults))
 
-        actions.onNext(SearchAction.ClearQuery)
+        actions.onNext(Action.ClearQuery)
 
         changes.assertValues(
-                ScreenStateChanges.UpdateSearchQuery(""),
-                ScreenStateChanges.RemoveResults
+                Changes.UpdateSearchQuery(""),
+                Changes.RemoveResults
         )
     }
 
     @Test
     fun `GIVEN dataSource has results WHEN execute search THEN search is in progress AND search is completed`() {
         val searchResults = SearchResults(items = listOf())
-        state.onNext(ScreenState(queryString = "iron man", results = ViewSearchResults.emptyResults))
+        state.onNext(State(queryString = "iron man", results = ViewSearchResults.emptyResults))
         dataSource.stub { on { search("iron man") } doReturn Single.just(searchResults) }
 
-        actions.onNext(SearchAction.ExecuteSearch)
+        actions.onNext(Action.ExecuteSearch)
 
         changes.assertValues(
-                ScreenStateChanges.ShowProgress,
-                ScreenStateChanges.AddResults(results = searchResults),
-                ScreenStateChanges.HideProgress
+                Changes.ShowProgress,
+                Changes.AddResults(results = searchResults),
+                Changes.HideProgress
         )
     }
 
     @Test
     fun `GIVEN dataSource errors WHEN execute search THEN search is in progress AND search failed`() {
         val exception = Throwable()
-        state.onNext(ScreenState(queryString = "iron man", results = ViewSearchResults.emptyResults))
+        state.onNext(State(queryString = "iron man", results = ViewSearchResults.emptyResults))
         dataSource.stub { on { search("iron man") } doReturn (Single.error(exception)) }
 
-        actions.onNext(SearchAction.ExecuteSearch)
+        actions.onNext(Action.ExecuteSearch)
 
         changes.assertValues(
-                ScreenStateChanges.ShowProgress,
-                ScreenStateChanges.HandleError(exception),
-                ScreenStateChanges.HideProgress
+                Changes.ShowProgress,
+                Changes.HandleError(exception),
+                Changes.HideProgress
         )
     }
 


### PR DESCRIPTION
- Introduced [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel) to hold the SearchStore in order to handle the lifecycle consistently. 

Now the UI state is preserved after the Activity is destroyed (for example after a rotation)

Some housekeeping:
- Split the MVIView interface into `ViewRender` and `ActionProvider` for better flexibility
- Created alias for the SearchStore 
- Created interface for the MovieDataSource so we don't rely on a concrete type
